### PR TITLE
fix: align pnpm action setup version

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 9.12.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile=false


### PR DESCRIPTION
## What changed
- Update .github/workflows/verify.yml to set pnpm/action-setup version to 9.12.0.

## Why
- CI failed in Setup pnpm because package.json pins pnpm@9.12.0 while the workflow requested version 9.

## Validation
- Ran pnpm verify in branch worktree successfully.