### PR TITLE
chore: add P1 orchestrator hardening backlog

### DIFF
--- a/tasks/P1-01.json
+++ b/tasks/P1-01.json
@@ -1,0 +1,30 @@
+{
+  "task_id": "P1-01",
+  "title": "Worker no-changes handoff regression tests",
+  "goal": "Ensure the worker treats clean worktrees with ahead commits as review-ready by creating or updating PRs instead of blocking issues.",
+  "inputs": [
+    "scripts/agent-worker.mjs",
+    "scripts/lib/worktree.mjs",
+    "README.md"
+  ],
+  "expected_outputs": [
+    "scripts/agent-worker.mjs",
+    "scripts/tests/agent-worker-no-changes.test.mjs",
+    "README.md"
+  ],
+  "constraints": [
+    "Cover both clean+ahead and clean+not-ahead scenarios.",
+    "Tests must run without live GitHub network calls.",
+    "Preserve existing issue labels and event payload shape."
+  ],
+  "verify_command": "node --test scripts/tests/agent-worker-no-changes.test.mjs",
+  "definition_of_done": [
+    "Worker marks runs ready for review when branch commits exist but working tree is clean.",
+    "Worker keeps no_changes status only when there are no working tree edits and no ahead commits.",
+    "Regression test demonstrates failure on previous blocked behavior."
+  ],
+  "rollback_note": "If this handoff path becomes unstable, disable branch-reuse PR handoff and fall back to manual PR creation while preserving run logs for triage.",
+  "priority": "P1",
+  "track": "runtime",
+  "risk_level": "medium"
+}

--- a/tasks/P1-02.json
+++ b/tasks/P1-02.json
@@ -1,0 +1,33 @@
+{
+  "task_id": "P1-02",
+  "title": "Reconciler canonical run-state cleanup",
+  "goal": "Make reconciliation collapse duplicate task runs into a canonical merged state so stale ready-for-review records do not linger.",
+  "inputs": [
+    "scripts/agent-reconciler.mjs",
+    "scripts/lib/state.mjs",
+    "scripts/agent-doctor.mjs"
+  ],
+  "expected_outputs": [
+    "scripts/agent-reconciler.mjs",
+    "scripts/agent-doctor.mjs",
+    "scripts/tests/reconciler-run-state.test.mjs"
+  ],
+  "constraints": [
+    "Reconciliation must be idempotent across repeated runs.",
+    "Do not mutate unrelated task history entries.",
+    "Prefer merged PR metadata when normalizing status and merged_at fields."
+  ],
+  "verify_command": "node --test scripts/tests/reconciler-run-state.test.mjs",
+  "definition_of_done": [
+    "Only one latest canonical run status remains for each merged task.",
+    "Doctor summary reports ready_for_review as zero after reconciliation for fully merged queues.",
+    "Reconciler tests cover duplicate-run normalization behavior."
+  ],
+  "rollback_note": "If canonicalization causes incorrect history, disable normalization writes and run reconciler in read-only mode until state migration rules are corrected.",
+  "dependencies": [
+    "P1-01"
+  ],
+  "priority": "P1",
+  "track": "control-plane",
+  "risk_level": "medium"
+}

--- a/tasks/P1-03.json
+++ b/tasks/P1-03.json
@@ -1,0 +1,34 @@
+{
+  "task_id": "P1-03",
+  "title": "Automatic merged branch cleanup",
+  "goal": "Automatically delete merged task branches and prune stale task worktrees after successful reconciliation.",
+  "inputs": [
+    "scripts/agent-reconciler.mjs",
+    "scripts/lib/worktree.mjs",
+    "scripts/agent-daemon.sh"
+  ],
+  "expected_outputs": [
+    "scripts/agent-reconciler.mjs",
+    "scripts/lib/worktree.mjs",
+    "scripts/tests/branch-cleanup.test.mjs",
+    "README.md"
+  ],
+  "constraints": [
+    "Only delete branches matching agent/P0-## or agent/P1-## with merged PRs.",
+    "Never delete protected branches such as main or master.",
+    "Support dry-run mode that prints planned deletions without mutating git state."
+  ],
+  "verify_command": "node --test scripts/tests/branch-cleanup.test.mjs",
+  "definition_of_done": [
+    "Merged task branches are automatically cleaned from remote when safe.",
+    "Stale local task worktrees can be pruned without touching active runs.",
+    "Cleanup logic is covered by tests including dry-run behavior."
+  ],
+  "rollback_note": "If cleanup deletes unexpected refs, disable automatic deletion and run in dry-run mode while restoring branch selection guards.",
+  "dependencies": [
+    "P1-02"
+  ],
+  "priority": "P1",
+  "track": "control-plane",
+  "risk_level": "high"
+}

--- a/tasks/P1-04.json
+++ b/tasks/P1-04.json
@@ -1,0 +1,34 @@
+{
+  "task_id": "P1-04",
+  "title": "Conflict-aware lockfile merge policy",
+  "goal": "Reduce merge conflict churn by adding branch-sync and lockfile conflict recovery rules to worker execution.",
+  "inputs": [
+    "scripts/agent-worker.mjs",
+    "scripts/lib/worktree.mjs",
+    "README.md"
+  ],
+  "expected_outputs": [
+    "scripts/agent-worker.mjs",
+    "scripts/lib/worktree.mjs",
+    "scripts/tests/conflict-recovery.test.mjs",
+    "README.md"
+  ],
+  "constraints": [
+    "When pnpm-lock.yaml conflicts, regenerate via pnpm install --lockfile-only.",
+    "Do not discard non-lockfile task changes during conflict recovery.",
+    "After repeated conflict failures, mark issue blocked with an actionable remediation comment."
+  ],
+  "verify_command": "node --test scripts/tests/conflict-recovery.test.mjs",
+  "definition_of_done": [
+    "Worker can recover from lockfile conflicts without manual intervention in common cases.",
+    "Conflict recovery emits clear run events and issue comments.",
+    "Regression tests cover successful recovery and repeated-failure escalation."
+  ],
+  "rollback_note": "If automated conflict recovery is unsafe, disable lockfile auto-resolution and fall back to manual conflict resolution workflow.",
+  "dependencies": [
+    "P1-01"
+  ],
+  "priority": "P1",
+  "track": "runtime",
+  "risk_level": "high"
+}

--- a/tasks/P1-05.json
+++ b/tasks/P1-05.json
@@ -1,0 +1,34 @@
+{
+  "task_id": "P1-05",
+  "title": "Doctor JSON output and alert thresholds",
+  "goal": "Add machine-readable doctor output and severity thresholds so scheduled health checks can gate and alert automatically.",
+  "inputs": [
+    "scripts/agent-doctor.mjs",
+    "README.md",
+    "schemas/agent-event.schema.json"
+  ],
+  "expected_outputs": [
+    "scripts/agent-doctor.mjs",
+    "schemas/doctor-report.schema.json",
+    "scripts/tests/agent-doctor-json.test.mjs",
+    "README.md"
+  ],
+  "constraints": [
+    "JSON output must include summary counts, per-check detail, and recommended remediation actions.",
+    "Never print raw secret values in text or JSON modes.",
+    "Strict mode must return non-zero exit for configured failure thresholds."
+  ],
+  "verify_command": "node --test scripts/tests/agent-doctor-json.test.mjs",
+  "definition_of_done": [
+    "Doctor supports --format json with a stable schema.",
+    "Doctor supports --strict thresholds suitable for CI and cron alerting.",
+    "Tests validate schema shape and secret-redaction behavior."
+  ],
+  "rollback_note": "If JSON or strict mode causes false alarms, disable strict gating and continue using text-mode doctor checks until thresholds are recalibrated.",
+  "dependencies": [
+    "P1-02"
+  ],
+  "priority": "P1",
+  "track": "feedback-loop",
+  "risk_level": "low"
+}


### PR DESCRIPTION
## Summary
- add five new P1 task contracts (`P1-01` through `P1-05`) focused on orchestrator reliability and operational hardening
- scope includes no-changes regression coverage, reconciler state canonicalization, merged-branch cleanup, lockfile conflict recovery policy, and doctor JSON/strict output
- encode dependencies to keep execution order safe (`P1-02` depends on `P1-01`, `P1-03` and `P1-05` depend on `P1-02`, `P1-04` depends on `P1-01`)

## Verification
```bash
pnpm verify

Project structure verified successfully.
Validated 18 JSON files successfully.
Validated 17 task contracts successfully.
contracts/openapi/inference.yaml: validated in 19ms
=== Results: 6 passed, 0 failed ===
```