### PR TITLE
[P1-01] Worker no-changes handoff regression tests

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,49 +1,67 @@
-## Task
+Closes #28
 
-**Task ID:** P0-06
-**Title:** Runtime guardrails and backoff ladder
-**Goal:** Detect degeneration and apply safe backoff transitions within a single request.
+## Goal
+
+Ensure the worker treats clean worktrees with ahead commits as review-ready by creating or updating PRs instead of blocking issues.
 
 ## Changes
 
-### `services/steering-inference-api/src/guardrails/detector.ts`
-- Detects three degeneration signals: **repetition loops** (n-gram frequency), **language shift** (non-Latin character ratio), **entropy collapse** (unique token ratio)
-- Configurable thresholds via `DetectorConfig`
+### `scripts/agent-worker.mjs`
 
-### `services/steering-inference-api/src/guardrails/backoff-policy.ts`
-- Implements backoff ladder: `strong → medium → low → single-layer → off (no-steering)`
-- Scoped to active request context only — no global state mutation
-- Bounded by `maxBackoffSteps` — no infinite retry loops
-- Emits `TelemetryEvent` for each backoff step
-- `buildPostBackoffMetadata()` produces run metadata with active layers, preset, multiplier, and guardrail event trail
+- Extracted `resolveNoChangesOutcome()` — a pure function that decides the worker outcome when the working tree is clean:
+  - `ready_for_review` when ahead commits or an existing PR exist
+  - `no_changes` only when there are zero ahead commits AND no existing PR
+  - `has_changes` when the worktree is dirty (delegates to normal commit flow)
+- Exported `resolveNoChangesOutcome`, `countCommitsAheadOfBase`, `findTaskPr`, and `buildPrBody` for testability.
+- Refactored `main()` to delegate the no-changes decision to `resolveNoChangesOutcome`.
+- Guarded `main()` with `import.meta.url` check so the module can be imported in tests without triggering execution.
 
-### `services/steering-inference-api/tests/guardrails.test.ts`
-- 19 tests covering all detector signals, full/partial backoff sequences, telemetry emission, max-step bounds, and post-backoff metadata
+### `scripts/tests/agent-worker-no-changes.test.mjs` (new)
 
-## Verify Command Output
+- 11 tests using Node.js built-in test runner (`node:test`):
+  - **clean+ahead** → `ready_for_review` (3 variants: commits only, PR only, both)
+  - **clean+not-ahead** → `no_changes`
+  - **dirty worktree** → `has_changes` (2 variants)
+  - **regression** — verifies clean+ahead does NOT resolve to `no_changes`
+  - **payload shape** — verifies returned objects contain expected fields
+- Zero live GitHub network calls.
 
+## Verify command
+
+```bash
+node --test scripts/tests/agent-worker-no-changes.test.mjs
 ```
-pnpm test --filter steering-guardrails
 
- ✓ tests/guardrails.test.ts (19 tests) 5ms
+## Verify output
 
- Test Files  1 passed (1)
-      Tests  19 passed (19)
-   Duration  416ms
+```text
+▶ resolveNoChangesOutcome
+  ✔ returns ready_for_review when worktree is clean and branch has ahead commits
+  ✔ returns ready_for_review when worktree is clean and an existing PR exists
+  ✔ returns ready_for_review when both ahead commits and existing PR are present
+  ✔ returns no_changes when worktree is clean and no ahead commits exist
+  ✔ returns has_changes when working tree has modifications
+  ✔ returns has_changes even when ahead commits exist if worktree is dirty
+✔ resolveNoChangesOutcome
+▶ regression: clean+ahead must not be treated as blocked
+  ✔ clean worktree with ahead commits must NOT resolve to no_changes
+  ✔ no_changes is only returned when there are zero ahead commits AND no existing PR
+✔ regression: clean+ahead must not be treated as blocked
+▶ resolveNoChangesOutcome preserves expected payload shape
+  ✔ ready_for_review result contains commitsAhead and existingPr fields
+  ✔ no_changes result contains commitsAhead and existingPr fields
+  ✔ has_changes result only contains outcome field
+✔ resolveNoChangesOutcome preserves expected payload shape
+ℹ tests 11
+ℹ suites 3
+ℹ pass 11
+ℹ fail 0
 ```
 
-## Definition of Done
+## Rollback note
 
-- [x] Guardrail fixtures trigger expected backoff sequence
-- [x] Final metadata reflects post-backoff active layers
-- [x] Fallback to no-steering mode is supported
+If this handoff path becomes unstable, disable branch-reuse PR handoff and fall back to manual PR creation while preserving run logs for triage.
 
-## Constraints
+## Task contract
 
-- [x] Backoff applies only to active request context
-- [x] No infinite retry loops (bounded by maxBackoffSteps)
-- [x] Emit telemetry for each backoff step
-
-## Rollback Note
-
-If guardrails are overly aggressive, revert to monitor-only mode while preserving telemetry emission.
+- `tasks/P1-01.json`

--- a/scripts/agent-worker.mjs
+++ b/scripts/agent-worker.mjs
@@ -68,7 +68,7 @@ function trimOutput(output, maxLength = 6000) {
   return `${text.slice(0, maxLength)}\n... [truncated]`;
 }
 
-function buildPrBody({ task, taskId, issueNumber, verifyOutput }) {
+export function buildPrBody({ task, taskId, issueNumber, verifyOutput }) {
   return [
     `Closes #${issueNumber}`,
     "",
@@ -296,7 +296,7 @@ function ensureGitIdentityEnv() {
   };
 }
 
-function findTaskPr(repo, branch, token) {
+export function findTaskPr(repo, branch, token) {
   const prs = ghJson(
     [
       "pr",
@@ -343,7 +343,7 @@ function createPr(repo, branch, title, body, token, baseBranch) {
   return result.stdout.trim();
 }
 
-function countCommitsAheadOfBase(worktreeDir, branch, baseBranch) {
+export function countCommitsAheadOfBase(worktreeDir, branch, baseBranch) {
   runCommand("git", ["-C", worktreeDir, "fetch", "origin", baseBranch], {
     allowFailure: true,
   });
@@ -403,6 +403,17 @@ function upsertTaskPr({ repo, branch, token, task, taskId, issueNumber, verifyOu
   }
 
   return createPr(repo, branch, `[${taskId}] ${task.title}`, body, token, baseBranch);
+}
+
+export function resolveNoChangesOutcome({ hasChanges, commitsAhead, existingPr }) {
+  if (hasChanges) {
+    return { outcome: "has_changes" };
+  }
+  const hasBranchCommits = commitsAhead > 0;
+  if (hasBranchCommits || existingPr) {
+    return { outcome: "ready_for_review", commitsAhead, existingPr };
+  }
+  return { outcome: "no_changes", commitsAhead, existingPr: null };
 }
 
 async function finalizeReadyForReview({
@@ -793,15 +804,19 @@ async function main() {
 
     if (!hasGitChanges(worktreeDir)) {
       const commitsAhead = countCommitsAheadOfBase(worktreeDir, branch, baseBranch);
-      const hasBranchCommits = commitsAhead > 0;
       const existingPr = findTaskPr(args.repo, branch, token);
+      const noChangesResult = resolveNoChangesOutcome({
+        hasChanges: false,
+        commitsAhead,
+        existingPr,
+      });
 
-      if (hasBranchCommits || existingPr) {
+      if (noChangesResult.outcome === "ready_for_review") {
         logStep(
           `no working tree changes; reusing branch state (ahead=${commitsAhead}, existing_pr=${existingPr ? String(existingPr.number) : "none"})`,
         );
 
-        if (hasBranchCommits) {
+        if (commitsAhead > 0) {
           runCommand("git", ["-C", worktreeDir, "push", "-u", "origin", branch], {
             capture: false,
           });
@@ -1034,7 +1049,12 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error.message || error);
-  process.exit(1);
-});
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+if (process.argv[1] === __filename) {
+  main().catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}

--- a/scripts/tests/agent-worker-no-changes.test.mjs
+++ b/scripts/tests/agent-worker-no-changes.test.mjs
@@ -1,0 +1,173 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveNoChangesOutcome } from "../agent-worker.mjs";
+
+// ---------------------------------------------------------------------------
+// resolveNoChangesOutcome – unit tests
+// ---------------------------------------------------------------------------
+
+describe("resolveNoChangesOutcome", () => {
+  // ----- clean worktree WITH ahead commits → ready_for_review -----
+
+  it("returns ready_for_review when worktree is clean and branch has ahead commits", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 3,
+      existingPr: null,
+    });
+    assert.equal(result.outcome, "ready_for_review");
+    assert.equal(result.commitsAhead, 3);
+  });
+
+  it("returns ready_for_review when worktree is clean and an existing PR exists", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 0,
+      existingPr: { number: 42, url: "https://github.com/test/repo/pull/42" },
+    });
+    assert.equal(result.outcome, "ready_for_review");
+    assert.deepEqual(result.existingPr, {
+      number: 42,
+      url: "https://github.com/test/repo/pull/42",
+    });
+  });
+
+  it("returns ready_for_review when both ahead commits and existing PR are present", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 5,
+      existingPr: { number: 10, url: "https://github.com/test/repo/pull/10" },
+    });
+    assert.equal(result.outcome, "ready_for_review");
+    assert.equal(result.commitsAhead, 5);
+    assert.equal(result.existingPr.number, 10);
+  });
+
+  // ----- clean worktree with NO ahead commits → no_changes -----
+
+  it("returns no_changes when worktree is clean and no ahead commits exist", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 0,
+      existingPr: null,
+    });
+    assert.equal(result.outcome, "no_changes");
+    assert.equal(result.commitsAhead, 0);
+    assert.equal(result.existingPr, null);
+  });
+
+  // ----- dirty worktree → has_changes (normal commit flow) -----
+
+  it("returns has_changes when working tree has modifications", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: true,
+      commitsAhead: 0,
+      existingPr: null,
+    });
+    assert.equal(result.outcome, "has_changes");
+  });
+
+  it("returns has_changes even when ahead commits exist if worktree is dirty", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: true,
+      commitsAhead: 2,
+      existingPr: { number: 7, url: "https://github.com/test/repo/pull/7" },
+    });
+    assert.equal(result.outcome, "has_changes");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: previous behavior would have blocked clean+ahead worktrees
+// ---------------------------------------------------------------------------
+
+describe("regression: clean+ahead must not be treated as blocked", () => {
+  it("clean worktree with ahead commits must NOT resolve to no_changes", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 1,
+      existingPr: null,
+    });
+    assert.notEqual(
+      result.outcome,
+      "no_changes",
+      "Bug regression: clean worktree with ahead commits was previously blocked instead of review-ready",
+    );
+    assert.equal(result.outcome, "ready_for_review");
+  });
+
+  it("no_changes is only returned when there are zero ahead commits AND no existing PR", () => {
+    const noChanges = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 0,
+      existingPr: null,
+    });
+    assert.equal(noChanges.outcome, "no_changes");
+
+    const withCommits = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 1,
+      existingPr: null,
+    });
+    assert.equal(
+      withCommits.outcome,
+      "ready_for_review",
+      "Any ahead commits should trigger ready_for_review, not no_changes",
+    );
+
+    const withPr = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 0,
+      existingPr: { number: 99, url: "https://github.com/test/repo/pull/99" },
+    });
+    assert.equal(
+      withPr.outcome,
+      "ready_for_review",
+      "An existing PR should trigger ready_for_review, not no_changes",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event payload shape preservation
+// ---------------------------------------------------------------------------
+
+describe("resolveNoChangesOutcome preserves expected payload shape", () => {
+  it("ready_for_review result contains commitsAhead and existingPr fields", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 4,
+      existingPr: { number: 15, url: "https://github.com/test/repo/pull/15" },
+    });
+    assert.ok("outcome" in result);
+    assert.ok("commitsAhead" in result);
+    assert.ok("existingPr" in result);
+    assert.equal(typeof result.commitsAhead, "number");
+    assert.equal(typeof result.existingPr, "object");
+  });
+
+  it("no_changes result contains commitsAhead and existingPr fields", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: false,
+      commitsAhead: 0,
+      existingPr: null,
+    });
+    assert.ok("outcome" in result);
+    assert.ok("commitsAhead" in result);
+    assert.ok("existingPr" in result);
+    assert.equal(result.commitsAhead, 0);
+    assert.equal(result.existingPr, null);
+  });
+
+  it("has_changes result only contains outcome field", () => {
+    const result = resolveNoChangesOutcome({
+      hasChanges: true,
+      commitsAhead: 0,
+      existingPr: null,
+    });
+    assert.ok("outcome" in result);
+    assert.ok(!("commitsAhead" in result));
+    assert.ok(!("existingPr" in result));
+  });
+});


### PR DESCRIPTION
Closes #28

## Goal
Ensure the worker treats clean worktrees with ahead commits as review-ready by creating or updating PRs instead of blocking issues.

## Verify command
```bash
node --test scripts/tests/agent-worker-no-changes.test.mjs
```

## Verify output
```text
▶ resolveNoChangesOutcome
  ✔ returns ready_for_review when worktree is clean and branch has ahead commits (0.42575ms)
  ✔ returns ready_for_review when worktree is clean and an existing PR exists (0.590291ms)
  ✔ returns ready_for_review when both ahead commits and existing PR are present (0.349042ms)
  ✔ returns no_changes when worktree is clean and no ahead commits exist (0.061875ms)
  ✔ returns has_changes when working tree has modifications (0.047709ms)
  ✔ returns has_changes even when ahead commits exist if worktree is dirty (0.038292ms)
✔ resolveNoChangesOutcome (2.098291ms)
▶ regression: clean+ahead must not be treated as blocked
  ✔ clean worktree with ahead commits must NOT resolve to no_changes (0.097ms)
  ✔ no_changes is only returned when there are zero ahead commits AND no existing PR (0.071542ms)
✔ regression: clean+ahead must not be treated as blocked (0.24875ms)
▶ resolveNoChangesOutcome preserves expected payload shape
  ✔ ready_for_review result contains commitsAhead and existingPr fields (0.095125ms)
  ✔ no_changes result contains commitsAhead and existingPr fields (0.105709ms)
  ✔ has_changes result only contains outcome field (0.044333ms)
✔ resolveNoChangesOutcome preserves expected payload shape (0.34025ms)
ℹ tests 11
ℹ suites 3
ℹ pass 11
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 88.347125
```

## Rollback note
If this handoff path becomes unstable, disable branch-reuse PR handoff and fall back to manual PR creation while preserving run logs for triage.

## Task contract
- `tasks/P1-01.json`