### PR TITLE
chore: add P2 support and real-harness backlog tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ bash scripts/agent-daemon.sh reset
 
 After reconciliation the reconciler automatically deletes remote branches for merged task PRs and prunes stale local worktrees that no longer have active runs.
 
-Only branches matching `agent/P0-##` or `agent/P1-##` with merged PRs are deleted. Protected branches (`main`, `master`) are never touched.
+Only branches matching `agent/P0-##`, `agent/P1-##`, or `agent/P2-##` with merged PRs are deleted. Protected branches (`main`, `master`) are never touched.
 
 Use `DRY_RUN=1` (or `--dry-run`) to preview planned deletions without mutating git state:
 

--- a/schemas/agent-event.schema.json
+++ b/schemas/agent-event.schema.json
@@ -57,7 +57,7 @@
     },
     "task_id": {
       "type": "string",
-      "pattern": "^P[01]-\\d{2}$"
+      "pattern": "^P[0-2]-\\d{2}$"
     },
     "issue_number": {
       "type": "integer",

--- a/scripts/agent-reconciler.mjs
+++ b/scripts/agent-reconciler.mjs
@@ -46,7 +46,7 @@ function sleep(ms) {
 }
 
 function taskIdFromBranch(branch) {
-  const match = String(branch || "").match(/^agent\/(P[01]-\d{2})$/);
+  const match = String(branch || "").match(/^agent\/(P[0-2]-\d{2})$/);
   return match ? match[1] : null;
 }
 

--- a/scripts/bootstrap-github.sh
+++ b/scripts/bootstrap-github.sh
@@ -66,6 +66,7 @@ gh label create "status:blocked" --color "b60205" --description "Blocked" --forc
 
 gh label create "priority:P0" --color "d73a4a" --description "Highest priority" --force --repo "$repo"
 gh label create "priority:P1" --color "f9d0c4" --description "Secondary priority" --force --repo "$repo"
+gh label create "priority:P2" --color "fbca04" --description "Tertiary priority" --force --repo "$repo"
 
 gh label create "track:runtime" --color "0e8a16" --description "Runtime and inference" --force --repo "$repo"
 gh label create "track:control-plane" --color "1d76db" --description "Contracts and profile registry" --force --repo "$repo"

--- a/scripts/lib/branch-cleanup.mjs
+++ b/scripts/lib/branch-cleanup.mjs
@@ -1,6 +1,6 @@
 import { runCommand } from "./command.mjs";
 
-const TASK_BRANCH_PATTERN = /^agent\/P[01]-\d{2}$/;
+const TASK_BRANCH_PATTERN = /^agent\/P[0-2]-\d{2}$/;
 const PROTECTED_BRANCHES = new Set(["main", "master"]);
 
 export function isTaskBranch(branch) {

--- a/scripts/lib/events.mjs
+++ b/scripts/lib/events.mjs
@@ -67,7 +67,7 @@ export function validateEvent(event) {
     throw new Error("event data must be an object");
   }
 
-  if (!/^P[01]-\d{2}$/.test(String(event.task_id))) {
+  if (!/^P[0-2]-\d{2}$/.test(String(event.task_id))) {
     throw new Error(`event task_id is invalid: ${event.task_id}`);
   }
 }

--- a/scripts/lib/github.mjs
+++ b/scripts/lib/github.mjs
@@ -33,7 +33,7 @@ export function ghJson(args, options = {}) {
 }
 
 export function issueTaskIdFromTitle(title) {
-  const match = String(title).match(/\[(P[01]-\d{2})\]/);
+  const match = String(title).match(/\[(P[0-2]-\d{2})\]/);
   return match ? match[1] : null;
 }
 

--- a/scripts/lib/tasks.mjs
+++ b/scripts/lib/tasks.mjs
@@ -2,7 +2,7 @@ import path from "node:path";
 import { readFile } from "node:fs/promises";
 
 export function taskIdFromTitle(title) {
-  const match = String(title).match(/\[(P[01]-\d{2})\]/);
+  const match = String(title).match(/\[(P[0-2]-\d{2})\]/);
   return match ? match[1] : null;
 }
 

--- a/scripts/tests/branch-cleanup.test.mjs
+++ b/scripts/tests/branch-cleanup.test.mjs
@@ -29,8 +29,12 @@ describe("isTaskBranch", () => {
     assert.equal(isTaskBranch("master"), false);
   });
 
-  it("rejects agent/P2-01", () => {
-    assert.equal(isTaskBranch("agent/P2-01"), false);
+  it("accepts agent/P2-01", () => {
+    assert.equal(isTaskBranch("agent/P2-01"), true);
+  });
+
+  it("rejects agent/P3-01", () => {
+    assert.equal(isTaskBranch("agent/P3-01"), false);
   });
 
   it("rejects feature/something", () => {
@@ -81,13 +85,16 @@ describe("listMergedTaskBranches", () => {
     const prs = [
       { headRefName: "agent/P0-01", number: 10, mergedAt: "2024-01-01T00:00:00Z" },
       { headRefName: "agent/P1-05", number: 20, mergedAt: "2024-01-02T00:00:00Z" },
+      { headRefName: "agent/P2-03", number: 30, mergedAt: "2024-01-03T00:00:00Z" },
     ];
     const result = listMergedTaskBranches(prs);
-    assert.equal(result.length, 2);
+    assert.equal(result.length, 3);
     assert.equal(result[0].branch, "agent/P0-01");
     assert.equal(result[0].prNumber, 10);
     assert.equal(result[1].branch, "agent/P1-05");
     assert.equal(result[1].prNumber, 20);
+    assert.equal(result[2].branch, "agent/P2-03");
+    assert.equal(result[2].prNumber, 30);
   });
 
   it("filters out non-task branches", () => {
@@ -181,10 +188,11 @@ describe("deleteMergedBranches", () => {
     const prs = [
       { headRefName: "agent/P0-01", number: 10, mergedAt: "2024-01-01T00:00:00Z" },
       { headRefName: "agent/P1-05", number: 20, mergedAt: "2024-01-02T00:00:00Z" },
+      { headRefName: "agent/P2-03", number: 21, mergedAt: "2024-01-02T12:00:00Z" },
       { headRefName: "feature/skip", number: 30, mergedAt: "2024-01-03T00:00:00Z" },
     ];
     const results = deleteMergedBranches("owner/repo", prs, { dryRun: true });
-    assert.equal(results.length, 2);
+    assert.equal(results.length, 3);
     for (const r of results) {
       assert.equal(r.deleted, false);
       assert.equal(r.dryRun, true);
@@ -193,6 +201,8 @@ describe("deleteMergedBranches", () => {
     assert.equal(results[0].prNumber, 10);
     assert.equal(results[1].branch, "agent/P1-05");
     assert.equal(results[1].prNumber, 20);
+    assert.equal(results[2].branch, "agent/P2-03");
+    assert.equal(results[2].prNumber, 21);
   });
 
   it("skips non-task branches", () => {

--- a/scripts/validate-task-contracts.mjs
+++ b/scripts/validate-task-contracts.mjs
@@ -22,7 +22,7 @@ const REQUIRED_ARRAY_FIELDS = [
   "definition_of_done",
 ];
 
-const PRIORITIES = new Set(["P0", "P1"]);
+const PRIORITIES = new Set(["P0", "P1", "P2"]);
 const RISK_LEVELS = new Set(["low", "medium", "high"]);
 
 function isNonEmptyString(value) {
@@ -51,15 +51,15 @@ function validateTask(task, fileName) {
   }
 
   if (task.priority && !PRIORITIES.has(task.priority)) {
-    errors.push("priority must be one of: P0, P1");
+    errors.push("priority must be one of: P0, P1, P2");
   }
 
   if (task.risk_level && !RISK_LEVELS.has(task.risk_level)) {
     errors.push("risk_level must be one of: low, medium, high");
   }
 
-  if (task.task_id && !/^P[01]-\d{2}$/.test(task.task_id)) {
-    errors.push("task_id must match pattern P0-00 or P1-00");
+  if (task.task_id && !/^P[0-2]-\d{2}$/.test(task.task_id)) {
+    errors.push("task_id must match pattern P0-00, P1-00, or P2-00");
   }
 
   const expectedFileName = `${task.task_id}.json`;

--- a/tasks/P2-01.json
+++ b/tasks/P2-01.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "P2-01",
+  "title": "Provider-backed steering inference adapter",
+  "goal": "Replace the stub chat completion path with a real provider adapter that executes steering requests against a live model runtime.",
+  "inputs": [
+    "services/steering-inference-api/src/routes/chat-completions.ts",
+    "contracts/openapi/inference.yaml",
+    "model-and-layers.md"
+  ],
+  "expected_outputs": [
+    "services/steering-inference-api/src/providers/model-adapter.ts",
+    "services/steering-inference-api/src/routes/chat-completions.ts",
+    "services/steering-inference-api/tests/chat-completions.test.ts",
+    "README.md"
+  ],
+  "constraints": [
+    "Preserve OpenAI-compatible request and response shape.",
+    "Do not log raw prompts or secret tokens in runtime logs.",
+    "Keep deterministic unit tests by mocking provider calls."
+  ],
+  "verify_command": "pnpm test --filter steering-inference-api",
+  "definition_of_done": [
+    "Chat completions route calls a provider adapter instead of returning stub text.",
+    "Steering metadata is attached to successful responses and error paths remain deterministic.",
+    "Provider failures map to structured 5xx responses with retry-safe error codes."
+  ],
+  "rollback_note": "If live adapter behavior is unstable, switch routing back to the deterministic stub path behind a feature flag while keeping metadata validation enabled.",
+  "dependencies": [
+    "P0-05",
+    "P0-06"
+  ],
+  "priority": "P2",
+  "track": "runtime",
+  "risk_level": "high"
+}

--- a/tasks/P2-02.json
+++ b/tasks/P2-02.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "P2-02",
+  "title": "Gemma 4 Stage C multi-layer calibration sweep",
+  "goal": "Implement Stage C jobs that combine top Stage B layers into sparse multi-layer profiles and calibrate preset multipliers.",
+  "inputs": [
+    "jobs/sweeps/gemma4-stage-b.ts",
+    "artifacts/sweeps/README.md",
+    "steering-exec-plan.md"
+  ],
+  "expected_outputs": [
+    "jobs/sweeps/gemma4-stage-c.ts",
+    "jobs/sweeps/tests/gemma4-stage-c.test.ts",
+    "artifacts/sweeps/gemma4-stage-c-result.json",
+    "artifacts/sweeps/README.md"
+  ],
+  "constraints": [
+    "Use deterministic seeds and persist config used for each candidate.",
+    "Build multi-layer candidates from Stage B passing layers only.",
+    "Emit profile bundles consumable by Stage D and canary routing."
+  ],
+  "verify_command": "pnpm run sweep:gemma4:stageC",
+  "definition_of_done": [
+    "Stage C produces ranked multi-layer candidates with preset tables.",
+    "Output artifact includes model revision, dataset version, and selected layer sets.",
+    "Stage C run is reproducible from committed config and seed values."
+  ],
+  "rollback_note": "If Stage C quality regresses, freeze Stage B winners as temporary challengers and defer multi-layer promotion until calibration is corrected.",
+  "dependencies": [
+    "P0-12",
+    "P2-05"
+  ],
+  "priority": "P2",
+  "track": "evaluation",
+  "risk_level": "high"
+}

--- a/tasks/P2-03.json
+++ b/tasks/P2-03.json
@@ -1,0 +1,36 @@
+{
+  "task_id": "P2-03",
+  "title": "Gemma 4 Stage D champion-challenger bake-off",
+  "goal": "Run Stage D head-to-head experiments and emit machine-readable promotion decisions for Gemma 4 challengers versus current champion.",
+  "inputs": [
+    "jobs/sweeps/gemma4-stage-c.ts",
+    "services/eval-orchestrator/src/gate-checker.ts",
+    "feedback-loop.md"
+  ],
+  "expected_outputs": [
+    "jobs/sweeps/gemma4-stage-d.ts",
+    "jobs/sweeps/tests/gemma4-stage-d.test.ts",
+    "artifacts/sweeps/gemma4-stage-d-decision.json",
+    "services/eval-orchestrator/src/gate-checker.ts"
+  ],
+  "constraints": [
+    "Apply hard gates before weighted rank comparisons.",
+    "Record evidence bundle IDs and experiment IDs in decision artifacts.",
+    "Fail closed when required metrics are missing."
+  ],
+  "verify_command": "pnpm run sweep:gemma4:stageD && pnpm test --filter experiment-gates",
+  "definition_of_done": [
+    "Stage D produces explicit promote or hold decision artifacts.",
+    "Decision output includes hard-gate reasons and rank component breakdown.",
+    "Champion and challenger comparisons are reproducible from stored artifacts."
+  ],
+  "rollback_note": "If Stage D decisioning is inconsistent, lock promotion decisions to hold and require manual review using raw experiment metrics.",
+  "dependencies": [
+    "P2-01",
+    "P2-02",
+    "P0-09"
+  ],
+  "priority": "P2",
+  "track": "evaluation",
+  "risk_level": "high"
+}

--- a/tasks/P2-04.json
+++ b/tasks/P2-04.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "P2-04",
+  "title": "LangSmith trace ingestion for dataset mining",
+  "goal": "Connect trace-miner to live LangSmith trace exports so nightly datasets are sourced from real production failure traces.",
+  "inputs": [
+    "services/trace-miner/src/pipeline.ts",
+    "services/tracing/src/index.ts",
+    "feedback-loop.md"
+  ],
+  "expected_outputs": [
+    "services/trace-miner/src/langsmith-source.ts",
+    "services/trace-miner/src/cli.ts",
+    "services/trace-miner/tests/pipeline.test.ts",
+    "services/trace-miner/README.md"
+  ],
+  "constraints": [
+    "Support bounded time windows and pagination for trace fetches.",
+    "Sanitize sensitive metadata before dataset export.",
+    "Provide dry-run mode that does not mutate remote datasets or local artifacts unless requested."
+  ],
+  "verify_command": "pnpm test --filter trace-miner && pnpm run trace-miner:dry-run -- --source langsmith",
+  "definition_of_done": [
+    "Trace miner can pull candidate failures from LangSmith projects by environment.",
+    "Exported examples remain deterministic after sanitization and dedup.",
+    "CLI supports source selection and time-window arguments for nightly jobs."
+  ],
+  "rollback_note": "If live ingestion quality drops, disable LangSmith source mode and continue generating datasets from last known-good snapshot inputs.",
+  "dependencies": [
+    "P0-07",
+    "P0-10"
+  ],
+  "priority": "P2",
+  "track": "feedback-loop",
+  "risk_level": "medium"
+}

--- a/tasks/P2-05.json
+++ b/tasks/P2-05.json
@@ -1,0 +1,34 @@
+{
+  "task_id": "P2-05",
+  "title": "Vector trainer service for calibration artifacts",
+  "goal": "Add a vector-trainer service that produces versioned concept vector bundles and preset calibration tables from training corpora.",
+  "inputs": [
+    "model-and-layers.md",
+    "services/steering-engine/src/steering/vector-resolver.ts",
+    "contracts/schema/profile.json"
+  ],
+  "expected_outputs": [
+    "services/vector-trainer/package.json",
+    "services/vector-trainer/src/train.ts",
+    "services/vector-trainer/src/export.ts",
+    "services/vector-trainer/tests/vector-trainer.test.ts"
+  ],
+  "constraints": [
+    "Artifact output must include vector_bundle_id, model revision, and seed metadata.",
+    "Training pipeline must be deterministic for the same dataset and seed.",
+    "Export format must be directly resolvable by steering-engine vector resolver."
+  ],
+  "verify_command": "pnpm test --filter vector-trainer",
+  "definition_of_done": [
+    "Vector trainer emits versioned bundle artifacts and preset calibration tables.",
+    "Generated artifacts pass schema validation and resolve in runtime tests.",
+    "Training/export behavior is covered by deterministic unit tests."
+  ],
+  "rollback_note": "If training artifacts are unstable, pin runtime to previous vector bundle IDs and disable automatic bundle promotion.",
+  "dependencies": [
+    "P0-05"
+  ],
+  "priority": "P2",
+  "track": "control-plane",
+  "risk_level": "medium"
+}

--- a/tasks/P2-06.json
+++ b/tasks/P2-06.json
@@ -1,0 +1,36 @@
+{
+  "task_id": "P2-06",
+  "title": "Nightly promotion pipeline and canary handoff",
+  "goal": "Automate end-to-end nightly promotion flow from trace ingestion through Stage D decision output and canary configuration handoff.",
+  "inputs": [
+    "services/trace-miner/src/pipeline.ts",
+    "jobs/sweeps/gemma4-stage-d.ts",
+    "services/canary-router/src/router.ts"
+  ],
+  "expected_outputs": [
+    "jobs/nightly/promote.ts",
+    "jobs/nightly/tests/promote.test.ts",
+    "artifacts/releases/README.md",
+    "README.md"
+  ],
+  "constraints": [
+    "Pipeline must support dry-run mode with no production mutations.",
+    "Promotion handoff must include rollback payload for canary-router.",
+    "Fail pipeline when required evidence artifacts are missing or stale."
+  ],
+  "verify_command": "pnpm run promote:nightly -- --dry-run",
+  "definition_of_done": [
+    "Nightly job orchestrates dataset mining, experiment scoring, and promotion handoff in one workflow.",
+    "Release artifact includes decision summary, evidence links, and rollback instructions.",
+    "Dry-run execution is reproducible and safe for CI or scheduled checks."
+  ],
+  "rollback_note": "If nightly promotion flow fails, pause automatic handoff and require manual promotion review with static canary champion routing.",
+  "dependencies": [
+    "P2-03",
+    "P2-04",
+    "P0-11"
+  ],
+  "priority": "P2",
+  "track": "rollout",
+  "risk_level": "high"
+}

--- a/tasks/schema/task-contract.schema.json
+++ b/tasks/schema/task-contract.schema.json
@@ -20,7 +20,7 @@
   "properties": {
     "task_id": {
       "type": "string",
-      "pattern": "^P[01]-\\d{2}$"
+      "pattern": "^P[0-2]-\\d{2}$"
     },
     "title": {
       "type": "string",
@@ -74,7 +74,7 @@
     },
     "priority": {
       "type": "string",
-      "enum": ["P0", "P1"]
+      "enum": ["P0", "P1", "P2"]
     },
     "track": {
       "type": "string",


### PR DESCRIPTION
## Summary
- extend task parsing and validation from `P0/P1` to `P0/P1/P2` across schemas, validators, issue title parsing, reconciler branch parsing, event validation, and branch-cleanup matching
- add `priority:P2` bootstrap label support and update branch-cleanup docs/tests to include `agent/P2-##` task branches
- add six new P2 contracts (`P2-01`..`P2-06`) focused on the real steering harness track: provider-backed inference, Stage C/Stage D experiments, live LangSmith trace ingestion, vector trainer service, and nightly promotion handoff

## Verification
```bash
node --test scripts/tests/branch-cleanup.test.mjs
# 31 tests passed

pnpm verify
# Project structure verified successfully.
# Validated 24 JSON files successfully.
# Validated 23 task contracts successfully.
# contracts/openapi/inference.yaml: validated
# Results: 6 passed, 0 failed
```