### PR TITLE
chore: add P3 phase support and production rollout backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ bash scripts/agent-daemon.sh reset
 
 After reconciliation the reconciler automatically deletes remote branches for merged task PRs and prunes stale local worktrees that no longer have active runs.
 
-Only branches matching `agent/P0-##`, `agent/P1-##`, or `agent/P2-##` with merged PRs are deleted. Protected branches (`main`, `master`) are never touched.
+Only branches matching `agent/P0-##`, `agent/P1-##`, `agent/P2-##`, or `agent/P3-##` with merged PRs are deleted. Protected branches (`main`, `master`) are never touched.
 
 Use `DRY_RUN=1` (or `--dry-run`) to preview planned deletions without mutating git state:
 

--- a/schemas/agent-event.schema.json
+++ b/schemas/agent-event.schema.json
@@ -57,7 +57,7 @@
     },
     "task_id": {
       "type": "string",
-      "pattern": "^P[0-2]-\\d{2}$"
+      "pattern": "^P[0-3]-\\d{2}$"
     },
     "issue_number": {
       "type": "integer",

--- a/scripts/agent-reconciler.mjs
+++ b/scripts/agent-reconciler.mjs
@@ -46,7 +46,7 @@ function sleep(ms) {
 }
 
 function taskIdFromBranch(branch) {
-  const match = String(branch || "").match(/^agent\/(P[0-2]-\d{2})$/);
+  const match = String(branch || "").match(/^agent\/(P[0-3]-\d{2})$/);
   return match ? match[1] : null;
 }
 

--- a/scripts/bootstrap-github.sh
+++ b/scripts/bootstrap-github.sh
@@ -67,6 +67,7 @@ gh label create "status:blocked" --color "b60205" --description "Blocked" --forc
 gh label create "priority:P0" --color "d73a4a" --description "Highest priority" --force --repo "$repo"
 gh label create "priority:P1" --color "f9d0c4" --description "Secondary priority" --force --repo "$repo"
 gh label create "priority:P2" --color "fbca04" --description "Tertiary priority" --force --repo "$repo"
+gh label create "priority:P3" --color "5319e7" --description "Production rollout priority" --force --repo "$repo"
 
 gh label create "track:runtime" --color "0e8a16" --description "Runtime and inference" --force --repo "$repo"
 gh label create "track:control-plane" --color "1d76db" --description "Contracts and profile registry" --force --repo "$repo"

--- a/scripts/lib/branch-cleanup.mjs
+++ b/scripts/lib/branch-cleanup.mjs
@@ -1,6 +1,6 @@
 import { runCommand } from "./command.mjs";
 
-const TASK_BRANCH_PATTERN = /^agent\/P[0-2]-\d{2}$/;
+const TASK_BRANCH_PATTERN = /^agent\/P[0-3]-\d{2}$/;
 const PROTECTED_BRANCHES = new Set(["main", "master"]);
 
 export function isTaskBranch(branch) {

--- a/scripts/lib/events.mjs
+++ b/scripts/lib/events.mjs
@@ -67,7 +67,7 @@ export function validateEvent(event) {
     throw new Error("event data must be an object");
   }
 
-  if (!/^P[0-2]-\d{2}$/.test(String(event.task_id))) {
+  if (!/^P[0-3]-\d{2}$/.test(String(event.task_id))) {
     throw new Error(`event task_id is invalid: ${event.task_id}`);
   }
 }

--- a/scripts/lib/github.mjs
+++ b/scripts/lib/github.mjs
@@ -33,7 +33,7 @@ export function ghJson(args, options = {}) {
 }
 
 export function issueTaskIdFromTitle(title) {
-  const match = String(title).match(/\[(P[0-2]-\d{2})\]/);
+  const match = String(title).match(/\[(P[0-3]-\d{2})\]/);
   return match ? match[1] : null;
 }
 

--- a/scripts/lib/tasks.mjs
+++ b/scripts/lib/tasks.mjs
@@ -2,7 +2,7 @@ import path from "node:path";
 import { readFile } from "node:fs/promises";
 
 export function taskIdFromTitle(title) {
-  const match = String(title).match(/\[(P[0-2]-\d{2})\]/);
+  const match = String(title).match(/\[(P[0-3]-\d{2})\]/);
   return match ? match[1] : null;
 }
 

--- a/scripts/tests/branch-cleanup.test.mjs
+++ b/scripts/tests/branch-cleanup.test.mjs
@@ -33,8 +33,12 @@ describe("isTaskBranch", () => {
     assert.equal(isTaskBranch("agent/P2-01"), true);
   });
 
-  it("rejects agent/P3-01", () => {
-    assert.equal(isTaskBranch("agent/P3-01"), false);
+  it("accepts agent/P3-01", () => {
+    assert.equal(isTaskBranch("agent/P3-01"), true);
+  });
+
+  it("rejects agent/P4-01", () => {
+    assert.equal(isTaskBranch("agent/P4-01"), false);
   });
 
   it("rejects feature/something", () => {
@@ -86,15 +90,18 @@ describe("listMergedTaskBranches", () => {
       { headRefName: "agent/P0-01", number: 10, mergedAt: "2024-01-01T00:00:00Z" },
       { headRefName: "agent/P1-05", number: 20, mergedAt: "2024-01-02T00:00:00Z" },
       { headRefName: "agent/P2-03", number: 30, mergedAt: "2024-01-03T00:00:00Z" },
+      { headRefName: "agent/P3-04", number: 40, mergedAt: "2024-01-04T00:00:00Z" },
     ];
     const result = listMergedTaskBranches(prs);
-    assert.equal(result.length, 3);
+    assert.equal(result.length, 4);
     assert.equal(result[0].branch, "agent/P0-01");
     assert.equal(result[0].prNumber, 10);
     assert.equal(result[1].branch, "agent/P1-05");
     assert.equal(result[1].prNumber, 20);
     assert.equal(result[2].branch, "agent/P2-03");
     assert.equal(result[2].prNumber, 30);
+    assert.equal(result[3].branch, "agent/P3-04");
+    assert.equal(result[3].prNumber, 40);
   });
 
   it("filters out non-task branches", () => {
@@ -189,10 +196,11 @@ describe("deleteMergedBranches", () => {
       { headRefName: "agent/P0-01", number: 10, mergedAt: "2024-01-01T00:00:00Z" },
       { headRefName: "agent/P1-05", number: 20, mergedAt: "2024-01-02T00:00:00Z" },
       { headRefName: "agent/P2-03", number: 21, mergedAt: "2024-01-02T12:00:00Z" },
+      { headRefName: "agent/P3-04", number: 22, mergedAt: "2024-01-02T13:00:00Z" },
       { headRefName: "feature/skip", number: 30, mergedAt: "2024-01-03T00:00:00Z" },
     ];
     const results = deleteMergedBranches("owner/repo", prs, { dryRun: true });
-    assert.equal(results.length, 3);
+    assert.equal(results.length, 4);
     for (const r of results) {
       assert.equal(r.deleted, false);
       assert.equal(r.dryRun, true);
@@ -203,6 +211,8 @@ describe("deleteMergedBranches", () => {
     assert.equal(results[1].prNumber, 20);
     assert.equal(results[2].branch, "agent/P2-03");
     assert.equal(results[2].prNumber, 21);
+    assert.equal(results[3].branch, "agent/P3-04");
+    assert.equal(results[3].prNumber, 22);
   });
 
   it("skips non-task branches", () => {

--- a/scripts/validate-task-contracts.mjs
+++ b/scripts/validate-task-contracts.mjs
@@ -22,7 +22,7 @@ const REQUIRED_ARRAY_FIELDS = [
   "definition_of_done",
 ];
 
-const PRIORITIES = new Set(["P0", "P1", "P2"]);
+const PRIORITIES = new Set(["P0", "P1", "P2", "P3"]);
 const RISK_LEVELS = new Set(["low", "medium", "high"]);
 
 function isNonEmptyString(value) {
@@ -51,15 +51,15 @@ function validateTask(task, fileName) {
   }
 
   if (task.priority && !PRIORITIES.has(task.priority)) {
-    errors.push("priority must be one of: P0, P1, P2");
+    errors.push("priority must be one of: P0, P1, P2, P3");
   }
 
   if (task.risk_level && !RISK_LEVELS.has(task.risk_level)) {
     errors.push("risk_level must be one of: low, medium, high");
   }
 
-  if (task.task_id && !/^P[0-2]-\d{2}$/.test(task.task_id)) {
-    errors.push("task_id must match pattern P0-00, P1-00, or P2-00");
+  if (task.task_id && !/^P[0-3]-\d{2}$/.test(task.task_id)) {
+    errors.push("task_id must match pattern P0-00, P1-00, P2-00, or P3-00");
   }
 
   const expectedFileName = `${task.task_id}.json`;

--- a/tasks/P3-01.json
+++ b/tasks/P3-01.json
@@ -1,0 +1,34 @@
+{
+  "task_id": "P3-01",
+  "title": "Live canary rollout controller",
+  "goal": "Promote challenger profiles with live traffic phases and strict automatic rollback policies using production metrics.",
+  "inputs": [
+    "services/canary-router/src/router.ts",
+    "services/canary-router/src/rollback-policy.ts",
+    "jobs/nightly/promote.ts"
+  ],
+  "expected_outputs": [
+    "services/canary-router/src/controller.ts",
+    "services/canary-router/tests/controller.test.ts",
+    "services/canary-router/tests/live-rollout-simulation.test.ts",
+    "README.md"
+  ],
+  "constraints": [
+    "Rollout phase changes must be configurable without redeploy.",
+    "Rollback must trigger on degenerate rate, p95 latency, and error-rate thresholds.",
+    "Kill switch must always route to baseline no-steering path."
+  ],
+  "verify_command": "pnpm test --filter canary-router && pnpm run canary:simulation",
+  "definition_of_done": [
+    "Controller supports phase progression 10/50/100 with runtime config updates.",
+    "Rollback decision latency meets SLA under simulation tests.",
+    "Controller emits machine-readable events for phase changes and rollback actions."
+  ],
+  "rollback_note": "If controller logic is unstable, freeze rollout at champion-only routing and disable automatic phase advancement.",
+  "dependencies": [
+    "P2-06"
+  ],
+  "priority": "P3",
+  "track": "rollout",
+  "risk_level": "high"
+}

--- a/tasks/P3-02.json
+++ b/tasks/P3-02.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "P3-02",
+  "title": "Shadow traffic parity gate",
+  "goal": "Evaluate challenger responses in shadow mode and block rollout when parity or hard-gate thresholds regress.",
+  "inputs": [
+    "services/steering-inference-api/src/providers/model-adapter.ts",
+    "services/eval-orchestrator/src/gate-checker.ts",
+    "feedback-loop.md"
+  ],
+  "expected_outputs": [
+    "services/eval-orchestrator/src/shadow-parity.ts",
+    "services/eval-orchestrator/tests/shadow-parity.test.ts",
+    "services/steering-inference-api/src/shadow-runner.ts",
+    "README.md"
+  ],
+  "constraints": [
+    "Shadow mode must never affect user-visible response payloads.",
+    "Parity gate output must include per-metric deltas and confidence intervals.",
+    "Store parity results with experiment IDs for auditability."
+  ],
+  "verify_command": "pnpm test --filter eval-orchestrator",
+  "definition_of_done": [
+    "Shadow runner executes champion and challenger on mirrored traffic samples.",
+    "Parity gate emits pass/fail verdicts with machine-readable reasons.",
+    "Rollout path can consume parity verdicts as a precondition for phase advancement."
+  ],
+  "rollback_note": "If shadow runner causes overhead or instability, disable mirrored challenger execution and retain static gate checks.",
+  "dependencies": [
+    "P3-01",
+    "P2-03"
+  ],
+  "priority": "P3",
+  "track": "evaluation",
+  "risk_level": "high"
+}

--- a/tasks/P3-03.json
+++ b/tasks/P3-03.json
@@ -1,0 +1,34 @@
+{
+  "task_id": "P3-03",
+  "title": "Promotion governance and approval workflow",
+  "goal": "Require explicit human approval with evidence bundles before production promotion canary handoff.",
+  "inputs": [
+    "jobs/nightly/promote.ts",
+    "artifacts/releases/README.md",
+    "services/eval-orchestrator/src/gate-checker.ts"
+  ],
+  "expected_outputs": [
+    "jobs/nightly/approval-gate.ts",
+    "jobs/nightly/tests/approval-gate.test.ts",
+    "artifacts/releases/promotion-decision.schema.json",
+    "README.md"
+  ],
+  "constraints": [
+    "Promotion must fail closed when approval record is missing or invalid.",
+    "Evidence bundle must include experiment decision, parity report, and rollback plan.",
+    "Approval records must be immutable and timestamped."
+  ],
+  "verify_command": "node --test jobs/nightly/tests/approval-gate.test.ts",
+  "definition_of_done": [
+    "Nightly promotion flow blocks without approved decision artifact.",
+    "Approval artifact schema validates required evidence references.",
+    "Audit trail links each promotion to an approver identity and timestamp."
+  ],
+  "rollback_note": "If approval gate blocks healthy releases unexpectedly, switch to advisory mode while preserving immutable decision artifacts.",
+  "dependencies": [
+    "P3-02"
+  ],
+  "priority": "P3",
+  "track": "control-plane",
+  "risk_level": "medium"
+}

--- a/tasks/P3-04.json
+++ b/tasks/P3-04.json
@@ -1,0 +1,34 @@
+{
+  "task_id": "P3-04",
+  "title": "Production SLO dashboard and alert tuning",
+  "goal": "Define SLOs and ship alerting dashboards for degeneration, correctness, latency, and cost with low false-positive rates.",
+  "inputs": [
+    "agent-instrumentation-spec.md",
+    "services/telemetry/src",
+    "services/tracing/src"
+  ],
+  "expected_outputs": [
+    "dashboards/production/slo-dashboard.json",
+    "dashboards/production/alert-rules.yaml",
+    "docs/incident-runbook.md",
+    "README.md"
+  ],
+  "constraints": [
+    "Alert thresholds must map directly to rollout rollback thresholds.",
+    "Runbook must include on-call triage and rollback drill steps.",
+    "Dashboard queries must avoid exposing sensitive user content."
+  ],
+  "verify_command": "pnpm test --filter telemetry && pnpm test --filter tracing",
+  "definition_of_done": [
+    "SLO dashboard includes correctness, coherence, degeneration, latency, and cost panels.",
+    "Alert pack defines warning and critical severities with documented responders.",
+    "Incident runbook includes a validated rollback drill checklist."
+  ],
+  "rollback_note": "If alert tuning is noisy, revert to conservative thresholds and keep dashboards in observe-only mode until calibrated.",
+  "dependencies": [
+    "P3-01"
+  ],
+  "priority": "P3",
+  "track": "feedback-loop",
+  "risk_level": "medium"
+}

--- a/tasks/P3-05.json
+++ b/tasks/P3-05.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "P3-05",
+  "title": "Cost and quota guardrails",
+  "goal": "Enforce per-route token budgets and request quotas so production traffic cannot exceed cost or safety envelopes.",
+  "inputs": [
+    "services/steering-inference-api/src/providers/model-adapter.ts",
+    "services/canary-router/src/controller.ts",
+    "feedback-loop.md"
+  ],
+  "expected_outputs": [
+    "services/steering-inference-api/src/guardrails/cost-policy.ts",
+    "services/steering-inference-api/tests/cost-policy.test.ts",
+    "services/canary-router/src/budget-hooks.ts",
+    "README.md"
+  ],
+  "constraints": [
+    "Guardrails must support per-model and per-profile budget overrides.",
+    "Over-budget requests must return deterministic errors with retry guidance.",
+    "Policy decisions must be emitted as telemetry events for auditing."
+  ],
+  "verify_command": "pnpm test --filter steering-inference-api && pnpm test --filter canary-router",
+  "definition_of_done": [
+    "Inference path enforces token and cost budgets before provider execution.",
+    "Rollout controller receives budget breach signals and can halt phase progression.",
+    "Budget policy tests cover soft-limit warnings and hard-limit rejection behavior."
+  ],
+  "rollback_note": "If budget enforcement blocks valid traffic unexpectedly, disable hard limits and retain warning-only telemetry until policy thresholds are corrected.",
+  "dependencies": [
+    "P3-01",
+    "P2-01"
+  ],
+  "priority": "P3",
+  "track": "runtime",
+  "risk_level": "high"
+}

--- a/tasks/P3-06.json
+++ b/tasks/P3-06.json
@@ -1,0 +1,35 @@
+{
+  "task_id": "P3-06",
+  "title": "Security and compliance hardening",
+  "goal": "Harden trace, dataset, and rollout data handling with redaction, retention controls, and auditable access safeguards.",
+  "inputs": [
+    "services/trace-miner/src/langsmith-source.ts",
+    "services/trace-miner/src/pipeline.ts",
+    "agent-instrumentation-spec.md"
+  ],
+  "expected_outputs": [
+    "services/trace-miner/src/redaction-policy.ts",
+    "services/trace-miner/tests/redaction-policy.test.ts",
+    "docs/security/data-retention-policy.md",
+    "README.md"
+  ],
+  "constraints": [
+    "Redaction policy must cover prompt content, metadata, and known secret token patterns.",
+    "Retention windows must be configurable by environment.",
+    "Access/audit logs must never contain raw secret values."
+  ],
+  "verify_command": "pnpm test --filter trace-miner",
+  "definition_of_done": [
+    "Trace and dataset exports apply centralized redaction policy before persistence.",
+    "Retention policy documentation defines defaults and operational overrides.",
+    "Security tests cover secret redaction and retention-boundary behavior."
+  ],
+  "rollback_note": "If hardened redaction drops critical debugging fields, fall back to previous policy with manual review and immediate patch follow-up.",
+  "dependencies": [
+    "P3-04",
+    "P2-04"
+  ],
+  "priority": "P3",
+  "track": "control-plane",
+  "risk_level": "high"
+}

--- a/tasks/schema/task-contract.schema.json
+++ b/tasks/schema/task-contract.schema.json
@@ -20,7 +20,7 @@
   "properties": {
     "task_id": {
       "type": "string",
-      "pattern": "^P[0-2]-\\d{2}$"
+      "pattern": "^P[0-3]-\\d{2}$"
     },
     "title": {
       "type": "string",
@@ -74,7 +74,7 @@
     },
     "priority": {
       "type": "string",
-      "enum": ["P0", "P1", "P2"]
+      "enum": ["P0", "P1", "P2", "P3"]
     },
     "track": {
       "type": "string",


### PR DESCRIPTION
## Summary
- extend orchestration parsing/validation from `P0-P2` to `P0-P3` across task schema, runtime regexes, event schema, reconciler branch parsing, and bootstrap labels
- update branch-cleanup docs/tests to allow `agent/P3-##` task branches and keep protected branch safeguards unchanged
- add six new P3 contracts (`P3-01`..`P3-06`) focused on production rollout maturity: live canary control, shadow parity gates, approval governance, SLO/alerts, cost guardrails, and security hardening

## Verification
```bash
node --test scripts/tests/branch-cleanup.test.mjs
# 32 tests passed

pnpm verify
# Project structure verified successfully.
# Validated 30 JSON files successfully.
# Validated 29 task contracts successfully.
# contracts/openapi/inference.yaml: validated
# Results: 6 passed, 0 failed
```